### PR TITLE
Fix fabric.js import syntax causing blank page in design tool

### DIFF
--- a/src/pages/Designer.jsx
+++ b/src/pages/Designer.jsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useRef, useEffect } from 'react';
-import { fabric } from 'fabric';
+import * as fabric from 'fabric';
 import { jsPDF } from 'jspdf';
 import { createClient } from '@supabase/supabase-js';
 import { supabaseConfig, isMockAuth } from '../config/supabase';


### PR DESCRIPTION
## Problem
The design tool was showing a blank page with console errors due to incorrect fabric.js import syntax. The main error was:
```
SyntaxError: The requested module '/node_modules/.vite/deps/fabric.js?v=efbc100' does not provide an export named 'fabric'
```

## Solution
- Changed the import statement in `Designer.jsx` from `import { fabric } from 'fabric'` to `import * as fabric from 'fabric'`
- This matches the correct export format for the installed version of fabric.js
- Verified no other files in the project have the same import issue

## Testing
- The fix addresses the specific SyntaxError mentioned in the console
- All existing fabric.js usage in the code remains compatible with the new import syntax

## Files Changed
- `src/pages/Designer.jsx` - Updated fabric.js import statement