### PR TITLE
Fix Vite environment variable configuration for Supabase

### DIFF
--- a/src/config/supabase.js
+++ b/src/config/supabase.js
@@ -1,12 +1,13 @@
 // Supabase configuration
 // Replace these with your actual Supabase project credentials
 // You can get these from https://app.supabase.com/project/_/settings/api
+// Note: In Vite, environment variables must be prefixed with VITE_ to be accessible in the browser
 
 export const supabaseConfig = {
-  url: process.env.REACT_APP_SUPABASE_URL || 'https://your-project.supabase.co',
-  anonKey: process.env.REACT_APP_SUPABASE_ANON_KEY || 'your-anon-key'
+  url: import.meta.env.VITE_SUPABASE_URL || 'https://your-project.supabase.co',
+  anonKey: import.meta.env.VITE_SUPABASE_ANON_KEY || 'your-anon-key'
 };
 
 // For development/demo purposes, we'll use a mock auth system if Supabase isn't configured
-export const isMockAuth = !process.env.REACT_APP_SUPABASE_URL || 
-                         process.env.REACT_APP_SUPABASE_URL === 'https://your-project.supabase.co';
+export const isMockAuth = !import.meta.env.VITE_SUPABASE_URL || 
+                         import.meta.env.VITE_SUPABASE_URL === 'https://your-project.supabase.co';


### PR DESCRIPTION
## Problem
The application was showing a blank page with the error "Uncaught ReferenceError: process is not defined at supabase.js:3:8". This occurred because the Supabase configuration was trying to access `process.env` variables, but `process` is not available in the browser environment when using Vite.

## Solution
- ✅ Replaced all `process.env` references with `import.meta.env` (Vite's environment variable syntax)
- ✅ Updated environment variable names to use `VITE_` prefix (required for browser access in Vite)
- ✅ Added explanatory comments about Vite environment variable requirements
- ✅ Maintained backward compatibility with fallback values for development

## Changes Made
- Updated `src/config/supabase.js` to use Vite-compatible environment variable access
- Changed `REACT_APP_SUPABASE_URL` → `VITE_SUPABASE_URL`
- Changed `REACT_APP_SUPABASE_ANON_KEY` → `VITE_SUPABASE_ANON_KEY`

## Testing
The mock authentication system will continue to work for development when no Supabase credentials are provided, allowing the design tool to function properly.

## Environment Variables
If you want to use real Supabase credentials, create a `.env` file with:
```
VITE_SUPABASE_URL=your-supabase-url
VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
```